### PR TITLE
fix(ci): Apply HTML Proofer ignore URLs correctly

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -21,7 +21,7 @@ jobs:
       - name: "Test Website (extended)"
         if: "${{ github.event_name == 'schedule' }}"
         run: |
-          htmlproofer --checks "Links,Images,Scripts,Favicon,OpenGraph" --ignore-missing-alt ./src/public/
+          htmlproofer --checks "Links,Images,Scripts,Favicon,OpenGraph" --ignore-missing-alt --ignore-urls "/www.reddit.com/,/www.npmjs.com/" ./src/public/
       - name: "Test Website"
         if: "${{ github.event_name != 'schedule' }}"
         run: |


### PR DESCRIPTION
I forgot to do this in my last PR. The ignoreURLs which I needed were only applied to the every commit HTML Proofer command and not the scheduled/cron one.